### PR TITLE
Changed swarm output directory to be the current swarm id

### DIFF
--- a/src/bin/lightdock-rust.rs
+++ b/src/bin/lightdock-rust.rs
@@ -124,9 +124,10 @@ fn run() {
     }
 }
 
-fn parse_swarm_id(filename: &str) -> Option<i32> {
-    filename
-        .strip_prefix("initial_positions_")
+fn parse_swarm_id(path: &Path) -> Option<i32> {
+    path.file_name()
+        .and_then(|s| s.to_str())
+        .and_then(|s| s.strip_prefix("initial_positions_"))
         .and_then(|s| s.strip_suffix(".dat"))
         .and_then(|s| s.parse::<i32>().ok())
 }
@@ -143,7 +144,8 @@ fn simulate(setup: &SetupFile, swarm_filename: &str, steps: u32, method: Method)
     };
 
     println!("Reading starting positions from {:?}", swarm_filename);
-    let swarm_id = parse_swarm_id(swarm_filename).expect("Could not parse swarm from swarm filename");
+    let file_path = Path::new(swarm_filename);
+    let swarm_id = parse_swarm_id(file_path).expect("Could not parse swarm from swarm filename");
     println!("Swarm ID {:?}", swarm_id);
     let swarm_directory = format!("swarm_{}", swarm_id);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,15 +20,17 @@ use scoring::Score;
 pub struct GSO<'a> {
     pub swarm: Swarm<'a>,
     pub rng: StdRng,
+    pub output_directory: String
 }
 
 
 impl<'a> GSO<'a> {
     pub fn new(positions: &[Vec<f64>], seed: u64, scoring: &'a Box<dyn Score>, use_anm: bool,
-        rec_num_anm: usize, lig_num_anm: usize) -> Self {
+        rec_num_anm: usize, lig_num_anm: usize, output_directory: String) -> Self {
         let mut gso = GSO {
             swarm: Swarm::new(),
             rng: SeedableRng::seed_from_u64(seed),
+            output_directory
         };
         gso.swarm.add_glowworms(positions, scoring, use_anm, rec_num_anm, lig_num_anm);
         gso
@@ -40,7 +42,7 @@ impl<'a> GSO<'a> {
             self.swarm.update_luciferin();
             self.swarm.movement_phase(&mut self.rng);
             if step % 10 == 0 || step == 1 {
-                match self.swarm.save(step) {
+                match self.swarm.save(step, &self.output_directory) {
                     Ok(ok) => ok,
                     Err(why) => panic!("Error saving GSO output: {:?}", why),
                 }

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -112,8 +112,8 @@ impl<'a> Swarm<'a> {
         }
     }
 
-    pub fn save(&mut self, step: u32) -> Result<(), Error> {
-        let path = format!("gso_{:?}.out", step);
+    pub fn save(&mut self, step: u32, output_directory: &str) -> Result<(), Error> {
+        let path = format!("{}/gso_{:?}.out", output_directory, step);
         let mut output = File::create(path)?;
         writeln!(output, "#Coordinates  RecID  LigID  Luciferin  Neighbor's number  Vision Range  Scoring")?;
         for glowworm in self.glowworms.iter() {


### PR DESCRIPTION
The way that lightdock-rust currently reads and writes files is a little confusing. Because swarms writes to the current directory by default, you either have to copy the structure files into every swarm directory, which seems inefficient, or you have to cd into every directory and refer to the structure and settings files using dotted relative paths. The change means that instead of doing this:

```bash
cd swarm_0
cp ../lightdock_1czy_protein.pdb ../lightdock_1czy_peptide.pdb .
cp ../rec_nm.npy ../lig_nm.npy .
cp -R ../../../data .
time ../../../target/release/lightdock-rust ../setup.json ../init/initial_positions_0.dat 100 dfire
```

You can just do this:

```bash
/target/release/lightdock-rust setup.json init/initial_positions_0.dat 100 dfire
```

You can also run this in parallel, because each process will be writing to a different directory and the file names will not clobber each other. It does this by extracting the swarm id from the initial_positions_number.dat filename, and using this as the directory name to write the gso_number.out files.

Let me know what you think.